### PR TITLE
Fix a crash when editable is false

### DIFF
--- a/RxMediaPicker/RxMediaPicker.swift
+++ b/RxMediaPicker/RxMediaPicker.swift
@@ -120,11 +120,12 @@ public enum RxMediaPickerError: Error {
     
     func processPhoto(info: [String : AnyObject],
                       observer: AnyObserver<(UIImage, UIImage?)>) {
-        guard let image = info[UIImagePickerControllerOriginalImage] as? UIImage,
-              let editedImage = info[UIImagePickerControllerEditedImage] as? UIImage else {
+        guard let image = info[UIImagePickerControllerOriginalImage] as? UIImage else {
             observer.on(.error(RxMediaPickerError.generalError))
             return
         }
+
+        let editedImage = info[UIImagePickerControllerEditedImage] as? UIImage
 
         observer.on(.next(image, editedImage))
         observer.on(.completed)

--- a/iOS Example/iOS Example/ViewController.swift
+++ b/iOS Example/iOS Example/ViewController.swift
@@ -117,7 +117,7 @@ class ViewController: UIViewController, RxMediaPickerDelegate {
 
     // RxMediaPickerDelegate
     func present(picker: UIImagePickerController) {
-        if moviePlayer.playbackState == .playing {
+        if moviePlayer != nil, moviePlayer.playbackState == .playing {
             moviePlayer.stop()
         }
 


### PR DESCRIPTION
The original code tested forcefully that editedImage is available, even though it is not guaranteed to be available (when editing mode is off, there will be no editedImage). 

This PR Fixes that and also fixes a minor issue to protect against a nil MPMoviePlayer. 